### PR TITLE
修复服务器关闭时 PlaceholderAPI 相关报错

### DIFF
--- a/src/moe/feo/bbstoper/PAPIExpansion.java
+++ b/src/moe/feo/bbstoper/PAPIExpansion.java
@@ -12,6 +12,16 @@ public class PAPIExpansion extends PlaceholderExpansion {
 
 	private static SQLer sql;
 
+	private String author;
+	private String identifier;
+	private String version;
+
+	PAPIExpansion() {
+		this.author = BBSToper.getInstance().getDescription().getAuthors().toString();
+		this.identifier = BBSToper.getInstance().getDescription().getName().toLowerCase();
+		this.version = BBSToper.getInstance().getDescription().getVersion();
+	}
+
 	public static void setSQLer(SQLer sql) {
 		PAPIExpansion.sql = sql;
 	}
@@ -31,17 +41,17 @@ public class PAPIExpansion extends PlaceholderExpansion {
 
 	@Override
 	public String getAuthor() {
-		return BBSToper.getInstance().getDescription().getAuthors().toString();
+		return author;
 	}
 
 	@Override
 	public String getIdentifier() {
-		return BBSToper.getInstance().getDescription().getName().toLowerCase();
+		return identifier;
 	}
 
 	@Override
 	public String getVersion() {
-		return BBSToper.getInstance().getDescription().getVersion();
+		return version;
 	}
 
 	@Override


### PR DESCRIPTION
大致报错如下：
```
[23:23:24] [Server thread/ERROR]: Could not pass event PluginDisableEvent to PlaceholderAPI v2.10.10
java.lang.NullPointerException: Cannot invoke "moe.feo.bbstoper.BBSToper.getDescription()" because the return value of "moe.feo.bbstoper.BBSToper.getInstance()" is null
	at moe.feo.bbstoper.PAPIExpansion.getIdentifier(PAPIExpansion.java:39) ~[BBSToper-3.6.5.jar:?]
	at me.clip.placeholderapi.expansion.PlaceholderExpansion.equals(PlaceholderExpansion.java:320) ~[PlaceholderAPI-2.10.10.jar:?]
	at com.google.common.collect.ImmutableSet$RegularSetBuilderImpl.add(ImmutableSet.java:754) ~[patched_1.17.1.jar:git-Purpur-1404]
	at com.google.common.collect.ImmutableSet.construct(ImmutableSet.java:178) ~[patched_1.17.1.jar:git-Purpur-1404]
	at com.google.common.collect.ImmutableSet.copyOf(ImmutableSet.java:212) ~[patched_1.17.1.jar:git-Purpur-1404]
	at me.clip.placeholderapi.expansion.manager.LocalExpansionManager.getExpansions(LocalExpansionManager.java:118) ~[PlaceholderAPI-2.10.10.jar:?]
	at me.clip.placeholderapi.expansion.manager.LocalExpansionManager.onPluginDisable(LocalExpansionManager.java:424) ~[PlaceholderAPI-2.10.10.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor31.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.17.1.jar:git-Purpur-1404]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:76) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:630) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.bukkit.plugin.java.JavaPluginLoader.disablePlugin(JavaPluginLoader.java:393) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.bukkit.plugin.SimplePluginManager.disablePlugin(SimplePluginManager.java:539) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.bukkit.plugin.SimplePluginManager.disablePlugins(SimplePluginManager.java:516) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.disablePlugins(CraftServer.java:478) ~[patched_1.17.1.jar:git-Purpur-1404]
	at net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:1056) ~[patched_1.17.1.jar:git-Purpur-1404]
	at net.minecraft.server.dedicated.DedicatedServer.stopServer(DedicatedServer.java:845) ~[patched_1.17.1.jar:git-Purpur-1404]
	at net.minecraft.server.MinecraftServer.close(MinecraftServer.java:1008) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.spigotmc.RestartCommand.shutdownServer(RestartCommand.java:92) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.spigotmc.RestartCommand.restart(RestartCommand.java:61) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.spigotmc.RestartCommand.restart(RestartCommand.java:40) ~[patched_1.17.1.jar:git-Purpur-1404]
	at org.spigotmc.RestartCommand$1.run(RestartCommand.java:31) ~[patched_1.17.1.jar:git-Purpur-1404]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1596) ~[patched_1.17.1.jar:git-Purpur-1404]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:518) ~[patched_1.17.1.jar:git-Purpur-1404]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1499) ~[patched_1.17.1.jar:git-Purpur-1404]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1292) ~[patched_1.17.1.jar:git-Purpur-1404]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:322) ~[patched_1.17.1.jar:git-Purpur-1404]
	at java.lang.Thread.run(Unknown Source) ~[?:?]
```
原因很简单，插件关闭以后，实例已经没有了，再获取就会报错。先把要的信息写到变量里就可以解决这个问题，谁不愿意看见后台没有报错呢。

---

我看明白了，```moe.feo.bbstoper.BBSToper``` 第 46 行有这么个东西：
```
Thread thread = new Thread(new Runnable(){
	@Override
	public void run() {
		Util.waitForAllTask();// 此方法会阻塞
		SQLManager.closeSQLer();
		bbstoper = null; // 第 46 行：这里赋值 null 了，所以报 NPE
	}
});
```
那报错就可以解释了